### PR TITLE
Fix operator installation in a disconnected environment

### DIFF
--- a/bundle/manifests/simple-demo-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/simple-demo-operator.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ spec:
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
                 - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: gcr.io/kubebuilder/kube-rbac-proxy@sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
@@ -110,7 +110,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/opdev/simple-demo-operator:0.0.3
+                image: quay.io/opdev/simple-demo-operator@sha256:25ca9cb1f3dc7b8ce0aba4d3383cac20f5f5a1298fbbfde4a6adab7b1000cb0e
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
This PR is to fix the DeployableByOlm test in disconnected environments. 

## Why DeployableByOlm fails in disconnected env

The test fails because of CSV failure, here are logs from preflight.log:
```
# subscription is reported to be ok
# csv is well-retrieved but never in the ready state
time="2022-01-10T08:48:50Z" level=debug msg="Waiting for object simple-demo-operator/simple-demo-operator.v0.0.3 to become ready..."
time="2022-01-10T08:48:53Z" level=debug msg="fetching csv simple-demo-operator.v0.0.3 from namespace simple-demo-operator"
time="2022-01-10T08:48:53Z" level=error msg="failed to fetch the csv simple-demo-operator.v0.0.3 from namespace simple-demo-operator: context deadline exceeded" 
```

From cluster logs we see that CSV is pending two images that failed to pull:
```
# CSV
NAME                                DISPLAY                      VERSION   REPLACES   PHASE
simple-demo-operator.v0.0.3         Simple Demo Operator         0.0.3                Installing

# images that are failing to pull
gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0 
quay.io/opdev/simple-demo-operator:0.0.3
```

These images could not be mirrored in the disconnected environment because the mirroring is done by digest (SHA) and images are referenced by tags.

## What was done to fix

The tags were replaced by digests as in this PR, I rebuilt all images:
```
quay.io/tkrishtop/simple-demo-operator-catalog:0.0.3
quay.io/tkrishtop/simple-demo-operator-bundle:0.0.3
quay.io/tkrishtop/simple-demo-operator:0.0.3
```
and then tested the change by [running Preflight tests with DCI](https://www.distributed-ci.io/jobs/ce12ca12-81d5-4af9-a521-05e8982f2b4a/jobStates). 
The tests are all green, here are results.json
```
{
  "image": "quay.io/tkrishtop/simple-demo-operator-bundle@sha256:e631c8dc7ab2d1ff67bf2731fd73820cb8e0214f9970d6ab1afca2f089d2fdb9",
  "passed": true,
  "certification_hash": "01139f58c09b2e5efcf99c9c8371dba9",
  "test_library": {
    "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
    "version": "1.0.6",
    "commit": "d01cac3c26138231eb9a19cd17b50f842e4f9c11"
  },
  "results": {
    "passed": [
      {
        "name": "ScorecardBasicSpecCheck",
        "elapsed_time": 14252,
        "description": "Check to make sure that all CRs have a spec block."
      },
      {
        "name": "ScorecardOlmSuiteCheck",
        "elapsed_time": 5213,
        "description": "Operator-sdk scorecard OLM Test Suite Check"
      },
      {
        "name": "DeployableByOLM",
        "elapsed_time": 89249,
        "description": "Checking if the operator could be deployed by OLM"
      },
      {
        "name": "ValidateOperatorBundle",
        "elapsed_time": 100,
        "description": "Validating Bundle image that checks if it can validate the content and format of the operator bundle"
      }
    ],
    "failed": [],
    "errors": []
  }
}
```
and CSV is ok in preflight.log
```
time="2022-01-14T11:41:07Z" level=debug msg="fetching csv simple-demo-operator.v0.0.3 from namespace simple-demo-operator"
time="2022-01-14T11:41:07Z" level=debug msg="CSV simple-demo-operator.v0.0.3 is created successfully in namespace simple-demo-operator"
time="2022-01-14T11:41:07Z" level=info msg="Successfully retrieved object simple-demo-operator/simple-demo-operator.v0.0.3"
```