### PR TITLE
adding in required annotations for a 0.0.7 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ IMAGE_BUILDER ?= podman
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.6
+VERSION ?= 0.0.7
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/simple-demo-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/simple-demo-operator.clusterserviceversion.yaml
@@ -16,12 +16,20 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.18.0+git
+    createdAt: "2023-11-13T21:56:03Z"
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
-  name: simple-demo-operator.v0.0.6
+  name: simple-demo-operator.v0.0.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -82,7 +90,9 @@ spec:
           - create
         serviceAccountName: simple-demo-operator-controller-manager
       deployments:
-      - name: simple-demo-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: simple-demo-operator-controller-manager
         spec:
           replicas: 1
           selector:
@@ -99,21 +109,27 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
-                - --v=10
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443
                   name: https
                   protocol: TCP
-                resources: {}
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/opdev/simple-demo-operator:0.0.6
+                image: quay.io/opdev/simple-demo-operator:0.0.7
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -197,4 +213,4 @@ spec:
   provider:
     name: The Partner Lifecycle Engineering Team
     url: github.com/opdev
-  version: 0.0.6
+  version: 0.0.7

--- a/bundle/manifests/tools.opdev.io_demoresources.yaml
+++ b/bundle/manifests/tools.opdev.io_demoresources.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.11.1
   creationTimestamp: null
   name: demoresources.tools.opdev.io
 spec:
@@ -61,5 +61,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: simple-demo-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.18.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/opdev/simple-demo-operator
-  newTag: 0.0.6
+  newTag: 0.0.7

--- a/config/manifests/bases/simple-demo-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/simple-demo-operator.clusterserviceversion.yaml
@@ -4,6 +4,13 @@ metadata:
   annotations:
     alm-examples: '[]'
     capabilities: Basic Install
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   labels:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported


### PR DESCRIPTION
- These new annotations will soon be required by preflight, so adding them to our test operator.
- Preparing the bundle directory for a 0.0.7 release